### PR TITLE
Fix the Ubuntu version in CI

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-deploy-wheel:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.8

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/l5kit-lock.yml
+++ b/.github/workflows/l5kit-lock.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   CI-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.7, 3.8]

--- a/.github/workflows/l5kit-setup.yml
+++ b/.github/workflows/l5kit-setup.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   CI-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.7, 3.8]


### PR DESCRIPTION
Github Actions platforms for `ubuntu-latest` are being updated to Ubuntu 22.04.
This PR specify Ubuntu 20.04 as platform for the CI tests due to compatibility issues with opencv/numpy/pytorch using the new ubuntu 22.04 images.